### PR TITLE
don't reset tree cache while drawing, avoid multiple updates per frame

### DIFF
--- a/src/Common/DirectoryTree.cs
+++ b/src/Common/DirectoryTree.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security;
 
 namespace BrowserFolders
 {
@@ -25,10 +27,18 @@ namespace BrowserFolders
             {
                 if (_subDirs == null)
                 {
-                    _subDirs = Info.GetDirectories()
-                        .OrderBy(x => x.Name, new Utils.WindowsStringComparer())
-                        .Select(x => new DirectoryTree(x))
-                        .ToList();
+                    try
+                    {
+                        _subDirs = Info.GetDirectories()
+                            .OrderBy(x => x.Name, new Utils.WindowsStringComparer())
+                            .Select(x => new DirectoryTree(x))
+                            .ToList();
+                    }
+                    catch (DirectoryNotFoundException) { }
+                    catch (SecurityException) { }
+                    catch (UnauthorizedAccessException) { }
+
+                    if (_subDirs == null) _subDirs = new List<DirectoryTree>();
                 }
 
                 return _subDirs;


### PR DESCRIPTION
- Handle subdirs disappearing while building cache
- don't let FS events reset the tree multiple times per frame
