### PR TITLE
recursive search

### DIFF
--- a/src/KK_Hooks_KK/HOutfitFolders.cs
+++ b/src/KK_Hooks_KK/HOutfitFolders.cs
@@ -61,14 +61,14 @@ namespace BrowserFolders.Hooks.KK
         }
         [HarmonyPostfix]
         [HarmonyPatch(typeof(FolderAssist), "CreateFolderInfoEx")]
-        internal static void RecursiveSearch(FolderAssist __instance)
+        internal static void RecursiveSearch(FolderAssist __instance, string folder)
         {
-            string coordinatepath = new DirectoryInfo(UserData.Path).FullName;
-            if (!Directory.Exists(coordinatepath + _currentRelativeFolder) || !RecursiveSearchBool)//make sure Recursive search is off by default or it will leak into other stuff that uses folder assist
+            //string coordinatepath = new DirectoryInfo(UserData.Path).FullName;
+            if (!Directory.Exists(folder) || !RecursiveSearchBool)//make sure Recursive search is off by default or it will leak into other stuff that uses folder assist
             {
-                return;
+                return;//known issue character cards doubling
             }
-            string[] folders = Directory.GetDirectories(coordinatepath + _currentRelativeFolder, "*", System.IO.SearchOption.AllDirectories); //grab child folders
+            string[] folders = Directory.GetDirectories(folder, "*", System.IO.SearchOption.AllDirectories); //grab child folders
             foreach (var Subfolder in folders)
             {
                 var Subfiles = Directory.GetFiles(Subfolder, "*.png");


### PR DESCRIPTION
Added ability for recursive search, seems like one instance is needed as it gets applied everywhere not sure where the best place to put the hook is, but the RecursiveSearchBool should be accessible.

I haven't applied to the other folder searches as I'd figure I'd need your input on the finer details.

The hook I made applies to more than just HOutfitFolders and am uncertain where to put the hook specifically and the bool that enables it.