### PR TITLE
Fix saving issues

### DIFF
--- a/src/HS2_BrowserFolders/NestedFilenamesMainGamePatch.cs
+++ b/src/HS2_BrowserFolders/NestedFilenamesMainGamePatch.cs
@@ -18,17 +18,17 @@ namespace BrowserFolders
 
             try
             {
-                var basePathForChara = new Uri(UserData.Path + "chara/female/");
-                var lookedAtPath = new Uri(path);
-                if (basePathForChara.IsBaseOf(lookedAtPath))
-                {
-                    __result = MainGameFolders.GetRelativePath(path, UserData.Path + "chara/female/");
-                    return false;
-                }
-
                 if (File.Exists(UserData.Path + "chara/female/" + path))
                 {
                     __result = path;
+                    return false;
+                }
+
+                var lookedAtPath = new Uri(path);
+                var basePathForChara = new Uri(UserData.Path + "chara/female/");
+                if (basePathForChara.IsBaseOf(lookedAtPath))
+                {
+                    __result = MainGameFolders.GetRelativePath(path, UserData.Path + "chara/female/");
                     return false;
                 }
 


### PR DESCRIPTION
If you wonder how this works :
The new Uri(somePath) would raise an exception if the path is relative. But then we test something with userdata/path + relativepath,. This second test never gets called because the exception was raised before. I just changed the order of the if statements. 