### PR TITLE
Performance improvements

### DIFF
--- a/src/AI_BrowserFolders/AI_BrowserFolders.csproj
+++ b/src/AI_BrowserFolders/AI_BrowserFolders.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +23,7 @@
     <DefineConstants>TRACE;DEBUG;AI</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>embedded</DebugType>
@@ -30,48 +33,65 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.3.1\lib\net35\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="AIAPI, Version=1.12.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionModdingAPI.AIAPI.1.12.2\lib\net46\AIAPI.dll</HintPath>
+    <Reference Include="AIAPI, Version=1.20.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionModdingAPI.AIAPI.1.20.3\lib\net46\AIAPI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="AI_ExtensibleSaveFormat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExtensibleSaveFormat.AIGirl.16.3.0\lib\net46\AI_ExtensibleSaveFormat.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.AIGirl.Assembly-CSharp.2020.5.29\lib\net46\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.AIGirl.Assembly-CSharp.2020.5.29.4\lib\net46\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="BepInEx, Version=5.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.5.1.0\lib\net35\BepInEx.dll</HintPath>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.AIGirl.Assembly-CSharp-firstpass.2020.5.29.4\lib\net46\Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BepInEx, Version=5.4.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.5.4.13\lib\net35\BepInEx.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.3.1\lib\net35\BepInEx.Harmony.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\BepInEx.Harmony.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Sirenix.Serialization, Version=2.0.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.AIGirl.Sirenix.Serialization.2020.5.29.4\lib\net46\Sirenix.Serialization.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="UniRx, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.AIGirl.UniRx.2020.5.29.4\lib\net46\UniRx.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.AIGirl.UnityEngine.CoreModule.2018.2.21.1\lib\net46\UnityEngine.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.AIGirl.UnityEngine.CoreModule.2018.2.21.4\lib\net46\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.AIGirl.UnityEngine.CoreModule.2018.2.21.1\lib\net46\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.AIGirl.UnityEngine.CoreModule.2018.2.21.4\lib\net46\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.AIGirl.UnityEngine.IMGUIModule.2018.2.21.1\lib\net46\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.AIGirl.UnityEngine.IMGUIModule.2018.2.21.4\lib\net46\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.AIGirl.UnityEngine.UI.2018.2.21.1\lib\net46\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.AIGirl.UnityEngine.UI.2018.2.21.4\lib\net46\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.AIGirl.UnityEngine.UIModule.2018.2.21.1\lib\net46\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.AIGirl.UnityEngine.UIModule.2018.2.21.4\lib\net46\UnityEngine.UIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -84,7 +104,34 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="..\Common_AIHS2\Common_AIHS2.projitems" Label="Shared" />
   <Import Project="..\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\IllusionLibs.AIGirl.Assembly-CSharp.2020.5.29.4\build\IllusionLibs.AIGirl.Assembly-CSharp.targets" Condition="Exists('..\packages\IllusionLibs.AIGirl.Assembly-CSharp.2020.5.29.4\build\IllusionLibs.AIGirl.Assembly-CSharp.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\IllusionLibs.AIGirl.Assembly-CSharp.2020.5.29.4\build\IllusionLibs.AIGirl.Assembly-CSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.AIGirl.Assembly-CSharp.2020.5.29.4\build\IllusionLibs.AIGirl.Assembly-CSharp.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.AIGirl.Assembly-CSharp-firstpass.2020.5.29.4\build\IllusionLibs.AIGirl.Assembly-CSharp-firstpass.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.AIGirl.Assembly-CSharp-firstpass.2020.5.29.4\build\IllusionLibs.AIGirl.Assembly-CSharp-firstpass.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.AIGirl.Sirenix.Serialization.2020.5.29.4\build\IllusionLibs.AIGirl.Sirenix.Serialization.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.AIGirl.Sirenix.Serialization.2020.5.29.4\build\IllusionLibs.AIGirl.Sirenix.Serialization.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.AIGirl.UniRx.2020.5.29.4\build\IllusionLibs.AIGirl.UniRx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.AIGirl.UniRx.2020.5.29.4\build\IllusionLibs.AIGirl.UniRx.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.AIGirl.UnityEngine.CoreModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.CoreModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.AIGirl.UnityEngine.CoreModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.CoreModule.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.AIGirl.UnityEngine.IMGUIModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.IMGUIModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.AIGirl.UnityEngine.IMGUIModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.IMGUIModule.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.AIGirl.UnityEngine.UI.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.AIGirl.UnityEngine.UI.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UI.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.AIGirl.UnityEngine.UIModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UIModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.AIGirl.UnityEngine.UIModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UIModule.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets'))" />
+  </Target>
+  <Import Project="..\packages\IllusionLibs.AIGirl.Assembly-CSharp-firstpass.2020.5.29.4\build\IllusionLibs.AIGirl.Assembly-CSharp-firstpass.targets" Condition="Exists('..\packages\IllusionLibs.AIGirl.Assembly-CSharp-firstpass.2020.5.29.4\build\IllusionLibs.AIGirl.Assembly-CSharp-firstpass.targets')" />
+  <Import Project="..\packages\IllusionLibs.AIGirl.Sirenix.Serialization.2020.5.29.4\build\IllusionLibs.AIGirl.Sirenix.Serialization.targets" Condition="Exists('..\packages\IllusionLibs.AIGirl.Sirenix.Serialization.2020.5.29.4\build\IllusionLibs.AIGirl.Sirenix.Serialization.targets')" />
+  <Import Project="..\packages\IllusionLibs.AIGirl.UniRx.2020.5.29.4\build\IllusionLibs.AIGirl.UniRx.targets" Condition="Exists('..\packages\IllusionLibs.AIGirl.UniRx.2020.5.29.4\build\IllusionLibs.AIGirl.UniRx.targets')" />
+  <Import Project="..\packages\IllusionLibs.AIGirl.UnityEngine.CoreModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.CoreModule.targets" Condition="Exists('..\packages\IllusionLibs.AIGirl.UnityEngine.CoreModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.CoreModule.targets')" />
+  <Import Project="..\packages\IllusionLibs.AIGirl.UnityEngine.IMGUIModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.IMGUIModule.targets" Condition="Exists('..\packages\IllusionLibs.AIGirl.UnityEngine.IMGUIModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.IMGUIModule.targets')" />
+  <Import Project="..\packages\IllusionLibs.AIGirl.UnityEngine.UI.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UI.targets" Condition="Exists('..\packages\IllusionLibs.AIGirl.UnityEngine.UI.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UI.targets')" />
+  <Import Project="..\packages\IllusionLibs.AIGirl.UnityEngine.UIModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UIModule.targets" Condition="Exists('..\packages\IllusionLibs.AIGirl.UnityEngine.UIModule.2018.2.21.4\build\IllusionLibs.AIGirl.UnityEngine.UIModule.targets')" />
+  <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" />
 </Project>

--- a/src/AI_BrowserFolders/packages.config
+++ b/src/AI_BrowserFolders/packages.config
@@ -1,11 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IllusionLibs.AIGirl.Assembly-CSharp" version="2020.5.29" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.AIGirl.UnityEngine.CoreModule" version="2018.2.21.1" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.AIGirl.UnityEngine.IMGUIModule" version="2018.2.21.1" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.AIGirl.UnityEngine.UI" version="2018.2.21.1" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.AIGirl.UnityEngine.UIModule" version="2018.2.21.1" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.BepInEx" version="5.1.0" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.BepInEx.Harmony" version="2.0.3.1" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionModdingAPI.AIAPI" version="1.12.2" targetFramework="net46" developmentDependency="true" />
+  <package id="BepInEx.Analyzers" version="1.0.4" targetFramework="net46" developmentDependency="true" />
+  <package id="ExtensibleSaveFormat.AIGirl" version="16.3.0" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.AIGirl.Assembly-CSharp" version="2020.5.29.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.AIGirl.Assembly-CSharp-firstpass" version="2020.5.29.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.AIGirl.Sirenix.Serialization" version="2020.5.29.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.AIGirl.UniRx" version="2020.5.29.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.AIGirl.UnityEngine.CoreModule" version="2018.2.21.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.AIGirl.UnityEngine.IMGUIModule" version="2018.2.21.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.AIGirl.UnityEngine.UI" version="2018.2.21.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.AIGirl.UnityEngine.UIModule" version="2018.2.21.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx" version="5.4.13" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx.Harmony" version="2.5.2" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionModdingAPI.AIAPI" version="1.20.3" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/src/Common_AIHS2/MakerFolders.cs
+++ b/src/Common_AIHS2/MakerFolders.cs
@@ -1,14 +1,13 @@
-﻿using System;
+﻿using CharaCustom;
+using HarmonyLib;
+using KKAPI.Maker;
+using KKAPI.Utilities;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection.Emit;
-using BepInEx.Harmony;
-using CharaCustom;
-using HarmonyLib;
-using KKAPI.Maker;
-using KKAPI.Utilities;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -27,10 +26,14 @@ namespace BrowserFolders
         private static VisibleWindow _lastRefreshed;
         private static FolderTreeView _folderTreeView;
 
+        private bool _guiActive;
+
         public MakerFolders()
         {
-            _folderTreeView = new FolderTreeView(AI_BrowserFolders.UserDataPath, AI_BrowserFolders.UserDataPath);
-            _folderTreeView.CurrentFolderChanged = RefreshCurrentWindow;
+            _folderTreeView = new FolderTreeView(AI_BrowserFolders.UserDataPath, AI_BrowserFolders.UserDataPath)
+            {
+                CurrentFolderChanged = RefreshCurrentWindow
+            };
 
             Harmony.CreateAndPatchAll(typeof(MakerFolders));
             MakerCardSave.RegisterNewCardSavePathModifier(CardSavePathModifier, null);
@@ -138,10 +141,15 @@ namespace BrowserFolders
             if (visibleWindow == VisibleWindow.None)
             {
                 _lastRefreshed = VisibleWindow.None;
-                _folderTreeView?.StopMonitoringFiles();
+                if (!_guiActive)
+                {
+                    _folderTreeView?.StopMonitoringFiles();
+                    _guiActive = false;
+                }
                 return;
             }
 
+            _guiActive = true;
             if (_lastRefreshed != visibleWindow) RefreshCurrentWindow();
 
             var screenRect = GetDisplayRect();
@@ -236,7 +244,7 @@ namespace BrowserFolders
                 var info = ___charaLoadWinA.GetSelectInfo();
                 var info2 = ___charaLoadWinB.GetSelectInfo();
                 __instance.FusionProc(info.info.FullPath, info2.info.FullPath);
-                Traverse.Create(__instance).Field("isFusion").SetValue(true);
+                __instance.isFusion = true;
             });
         }
 

--- a/src/Common_AIHS2/MakerOutfitFolders.cs
+++ b/src/Common_AIHS2/MakerOutfitFolders.cs
@@ -1,14 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection.Emit;
-using AIChara;
-using BepInEx.Harmony;
+﻿using AIChara;
 using CharaCustom;
 using HarmonyLib;
 using KKAPI.Maker;
 using KKAPI.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.Emit;
 using UnityEngine;
 
 namespace BrowserFolders
@@ -24,10 +23,14 @@ namespace BrowserFolders
         private static VisibleWindow _lastRefreshed;
         private static FolderTreeView _folderTreeView;
 
+        private bool _guiActive;
+
         public MakerOutfitFolders()
         {
-            _folderTreeView = new FolderTreeView(AI_BrowserFolders.UserDataPath, AI_BrowserFolders.UserDataPath);
-            _folderTreeView.CurrentFolderChanged = RefreshCurrentWindow;
+            _folderTreeView = new FolderTreeView(AI_BrowserFolders.UserDataPath, AI_BrowserFolders.UserDataPath)
+            {
+                CurrentFolderChanged = RefreshCurrentWindow
+            };
 
             Harmony.CreateAndPatchAll(typeof(MakerOutfitFolders));
         }
@@ -111,15 +114,21 @@ namespace BrowserFolders
         }
 
         public void OnGui()
-        {//todo  When loading a coordinate it resets to the main folder without deselect in menu
+        {
+            //todo  When loading a coordinate it resets to the main folder without deselect in menu
             var visibleWindow = IsVisible();
             if (visibleWindow == VisibleWindow.None)
             {
                 _lastRefreshed = VisibleWindow.None;
-                _folderTreeView?.StopMonitoringFiles();
+                if (_guiActive)
+                {
+                    _folderTreeView?.StopMonitoringFiles();
+                    _guiActive = false;
+                }
                 return;
             }
 
+            _guiActive = true;
             if (_lastRefreshed != visibleWindow) RefreshCurrentWindow();
 
             var screenRect = MakerFolders.GetDisplayRect();

--- a/src/Common_AIHS2/StudioCharaFolders.cs
+++ b/src/Common_AIHS2/StudioCharaFolders.cs
@@ -1,11 +1,10 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using BepInEx;
-using BepInEx.Harmony;
+﻿using BepInEx;
 using HarmonyLib;
 using KKAPI.Utilities;
 using Studio;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using UnityEngine;
 
 namespace BrowserFolders
@@ -27,8 +26,10 @@ namespace BrowserFolders
             if (_lastEntry != null && _lastEntry != entry)
             {
                 _lastEntry.FolderTreeView?.StopMonitoringFiles();
+
                 _lastEntry = null;
             }
+
             if (entry == null) return;
             _lastEntry = entry;
             var windowRect = new Rect((int)(Screen.width * 0.06f), (int)(Screen.height * 0.32f), (int)(Screen.width * 0.13f), (int)(Screen.height * 0.4f));
@@ -179,7 +180,8 @@ namespace BrowserFolders
 
             public void ApplyFilter()
             {
-                GetCharaFileInfos().RemoveAll(cfi => Utils.NormalizePath(Path.GetDirectoryName(cfi.file)) != CurrentFolder);
+                var currentFolder = CurrentFolder;
+                GetCharaFileInfos().RemoveAll(cfi => Utils.GetNormalizedDirectoryName(cfi.file) != currentFolder);
             }
 
             public void InitCharaList(bool force)
@@ -204,13 +206,15 @@ namespace BrowserFolders
 
             private List<CharaFileInfo> GetCharaFileInfos()
             {
-                return Traverse.Create(_charaList)?.Field<CharaFileSort>("charaFileSort")?.Value?.cfiList;
+                List<CharaFileInfo> result = null;
+                _charaList.SafeProc(cl => cl.charaFileSort.SafeProc(cfs => result = cfs.cfiList));
+                return result;
             }
 
             private int GetSex()
             {
                 if (_sex == -1)
-                    _sex = Traverse.Create(_charaList).Field<int>("sex").Value;
+                    _sex = _charaList.sex;
                 return _sex;
             }
 

--- a/src/EC_BrowserFolders/EC_BrowserFolders.csproj
+++ b/src/EC_BrowserFolders/EC_BrowserFolders.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +23,7 @@
     <DefineConstants>TRACE;DEBUG;EC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>embedded</DebugType>
@@ -30,48 +33,61 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.3.1\lib\net35\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.EmotionCreators.Assembly-CSharp.2019.6.6\lib\net46\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.EmotionCreators.Assembly-CSharp.2019.6.6.4\lib\net46\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="BepInEx, Version=5.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.5.1.0\lib\net35\BepInEx.dll</HintPath>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass.2019.6.6.4\lib\net46\Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BepInEx, Version=5.4.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.5.4.13\lib\net35\BepInEx.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.3.1\lib\net35\BepInEx.Harmony.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\BepInEx.Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ECAPI, Version=1.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionModdingAPI.ECAPI.1.13.0\lib\net46\ECAPI.dll</HintPath>
+    <Reference Include="ECAPI, Version=1.20.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionModdingAPI.ECAPI.1.20.3\lib\net46\ECAPI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="EC_ExtensibleSaveFormat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExtensibleSaveFormat.EmotionCreators.16.3.0\lib\net46\EC_ExtensibleSaveFormat.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="IL, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.EmotionCreators.IL.2019.6.6\lib\net46\IL.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.EmotionCreators.IL.2019.6.6.4\lib\net46\IL.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="UniRx, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.EmotionCreators.UniRx.2019.6.6.4\lib\net46\UniRx.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.2017.4.24.1\lib\net46\UnityEngine.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.2017.4.24.4\lib\net46\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.2017.4.24.1\lib\net46\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.2017.4.24.4\lib\net46\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule.2017.4.24.1\lib\net46\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule.2017.4.24.4\lib\net46\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.EmotionCreators.UnityEngine.UI.2017.4.24.1\lib\net46\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.EmotionCreators.UnityEngine.UI.2017.4.24.4\lib\net46\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -92,6 +108,31 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="..\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.EmotionCreators.Assembly-CSharp.2019.6.6.4\build\IllusionLibs.EmotionCreators.Assembly-CSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.EmotionCreators.Assembly-CSharp.2019.6.6.4\build\IllusionLibs.EmotionCreators.Assembly-CSharp.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass.2019.6.6.4\build\IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass.2019.6.6.4\build\IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.EmotionCreators.IL.2019.6.6.4\build\IllusionLibs.EmotionCreators.IL.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.EmotionCreators.IL.2019.6.6.4\build\IllusionLibs.EmotionCreators.IL.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.EmotionCreators.UniRx.2019.6.6.4\build\IllusionLibs.EmotionCreators.UniRx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.EmotionCreators.UniRx.2019.6.6.4\build\IllusionLibs.EmotionCreators.UniRx.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.EmotionCreators.UnityEngine.UI.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.UI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.EmotionCreators.UnityEngine.UI.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.UI.targets'))" />
+  </Target>
+  <Import Project="..\packages\IllusionLibs.EmotionCreators.Assembly-CSharp.2019.6.6.4\build\IllusionLibs.EmotionCreators.Assembly-CSharp.targets" Condition="Exists('..\packages\IllusionLibs.EmotionCreators.Assembly-CSharp.2019.6.6.4\build\IllusionLibs.EmotionCreators.Assembly-CSharp.targets')" />
+  <Import Project="..\packages\IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass.2019.6.6.4\build\IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass.targets" Condition="Exists('..\packages\IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass.2019.6.6.4\build\IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass.targets')" />
+  <Import Project="..\packages\IllusionLibs.EmotionCreators.IL.2019.6.6.4\build\IllusionLibs.EmotionCreators.IL.targets" Condition="Exists('..\packages\IllusionLibs.EmotionCreators.IL.2019.6.6.4\build\IllusionLibs.EmotionCreators.IL.targets')" />
+  <Import Project="..\packages\IllusionLibs.EmotionCreators.UniRx.2019.6.6.4\build\IllusionLibs.EmotionCreators.UniRx.targets" Condition="Exists('..\packages\IllusionLibs.EmotionCreators.UniRx.2019.6.6.4\build\IllusionLibs.EmotionCreators.UniRx.targets')" />
+  <Import Project="..\packages\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.targets" Condition="Exists('..\packages\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.CoreModule.targets')" />
+  <Import Project="..\packages\IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule.targets" Condition="Exists('..\packages\IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule.targets')" />
+  <Import Project="..\packages\IllusionLibs.EmotionCreators.UnityEngine.UI.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.UI.targets" Condition="Exists('..\packages\IllusionLibs.EmotionCreators.UnityEngine.UI.2017.4.24.4\build\IllusionLibs.EmotionCreators.UnityEngine.UI.targets')" />
 </Project>

--- a/src/EC_BrowserFolders/Hooks/MakerMapFolders.cs
+++ b/src/EC_BrowserFolders/Hooks/MakerMapFolders.cs
@@ -24,8 +24,10 @@ namespace BrowserFolders.Hooks
         public MakerMapFolders()
         {
             _folderTreeView =
-                new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+                new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path))
+                {
+                    CurrentFolderChanged = OnFolderChanged
+                };
 
             Harmony.CreateAndPatchAll(typeof(MakerMapFolders));
         }
@@ -86,12 +88,11 @@ namespace BrowserFolders.Hooks
         {
             _currentRelativeFolder = _folderTreeView.CurrentRelativeFolder;
 
-            if (_mapLoadScene == null) return;
-
-            var ccf = Traverse.Create(_mapLoadScene);
-
-            ccf.Method("CreateList").GetValue();
-            ccf.Method("RecreateScrollerList").GetValue();
+            _mapLoadScene.SafeProc(mls =>
+            {
+                mls.CreateList();
+                mls.RecreateScrollerList();
+            });
         }
 
         private static void TreeWindow(int id)

--- a/src/EC_BrowserFolders/Hooks/MakerMapSaveFolders.cs
+++ b/src/EC_BrowserFolders/Hooks/MakerMapSaveFolders.cs
@@ -24,8 +24,10 @@ namespace BrowserFolders.Hooks
         public MakerMapSaveFolders()
         {
             _folderTreeView =
-                new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+                new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path))
+                {
+                    CurrentFolderChanged = OnFolderChanged
+                };
 
             Harmony.CreateAndPatchAll(typeof(MakerMapSaveFolders));
         }
@@ -102,12 +104,11 @@ namespace BrowserFolders.Hooks
         {
             _currentRelativeFolder = _folderTreeView.CurrentRelativeFolder;
 
-            if (_mapSaveScene == null) return;
-
-            var ccf = Traverse.Create(_mapSaveScene);
-
-            ccf.Method("CreateList").GetValue();
-            ccf.Method("RecreateScrollerList").GetValue();
+            _mapSaveScene.SafeProc(mss =>
+            {
+                mss.CreateList();
+                mss.RecreateScrollerList();
+            });
         }
 
         private static void TreeWindow(int id)

--- a/src/EC_BrowserFolders/Hooks/MakerOutfitFolders.cs
+++ b/src/EC_BrowserFolders/Hooks/MakerOutfitFolders.cs
@@ -29,8 +29,10 @@ namespace BrowserFolders.Hooks
 
         public MakerOutfitFolders()
         {
-            _folderTreeView = new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+            _folderTreeView = new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path))
+            {
+                CurrentFolderChanged = OnFolderChanged
+            };
 
             Harmony.CreateAndPatchAll(typeof(MakerOutfitFolders));
         }
@@ -135,21 +137,20 @@ namespace BrowserFolders.Hooks
             var isSave = _saveOutfitToggle != null && _saveOutfitToggle.isOn;
             if (isLoad || isSave)
             {
-                var ccfTrav = Traverse.Create(_customCoordinateFile);
-                ccfTrav.Method("Initialize").GetValue();
+                _customCoordinateFile.Initialize();
 
                 // Fix default cards being shown when refreshing in this way
-                var lctrlTrav = ccfTrav.Field("listCtrl");
+                var listCtrl = _customCoordinateFile.listCtrl;
                 if (isSave)
                 {
-                    var lst = lctrlTrav.Field("lstFileInfo").GetValue<List<CustomFileInfo>>();
-                    var dis = lctrlTrav.Field("cfWindow").Field("forceHideCategoryNo").GetValue<int>();
+                    var lst = listCtrl.lstFileInfo;
+                    var dis = listCtrl.cfWindow.forceHideCategoryNo;
                     if (dis != -1)
                         foreach (var customFileInfo in lst.Where(x => x.category == dis)) customFileInfo.fic.Disvisible(true);
                 }
                 else
                 {
-                    lctrlTrav.Method("UpdateCategory").GetValue();
+                    listCtrl.UpdateCategory();
                 }
             }
         }

--- a/src/EC_BrowserFolders/Hooks/MakerPoseFolders.cs
+++ b/src/EC_BrowserFolders/Hooks/MakerPoseFolders.cs
@@ -24,8 +24,10 @@ namespace BrowserFolders.Hooks
         public MakerPoseFolders()
         {
             _folderTreeView =
-                new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+                new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path))
+                {
+                    CurrentFolderChanged = OnFolderChanged
+                };
 
             Harmony.CreateAndPatchAll(typeof(MakerPoseFolders));
         }
@@ -86,12 +88,11 @@ namespace BrowserFolders.Hooks
         {
             _currentRelativeFolder = _folderTreeView.CurrentRelativeFolder;
 
-            if (_poseLoadScene == null) return;
-
-            var ccf = Traverse.Create(_poseLoadScene);
-
-            ccf.Method("CreateList").GetValue();
-            ccf.Method("RecreateScrollerList").GetValue();
+            _poseLoadScene.SafeProc(pls =>
+            {
+                pls.CreateList();
+                pls.RecreateScrollerList();
+            });
         }
 
         private static void TreeWindow(int id)

--- a/src/EC_BrowserFolders/Hooks/MakerPoseSaveFolders.cs
+++ b/src/EC_BrowserFolders/Hooks/MakerPoseSaveFolders.cs
@@ -24,8 +24,10 @@ namespace BrowserFolders.Hooks
         public MakerPoseSaveFolders()
         {
             _folderTreeView =
-                new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+                new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path))
+                {
+                    CurrentFolderChanged = OnFolderChanged
+                };
 
             Harmony.CreateAndPatchAll(typeof(MakerPoseSaveFolders));
         }
@@ -101,12 +103,11 @@ namespace BrowserFolders.Hooks
         {
             _currentRelativeFolder = _folderTreeView.CurrentRelativeFolder;
 
-            if (_poseSaveScene == null) return;
-
-            var ccf = Traverse.Create(_poseSaveScene);
-
-            ccf.Method("CreateList").GetValue();
-            ccf.Method("RecreateScrollerList").GetValue();
+            _poseSaveScene.SafeProc(pss =>
+            {
+                pss.CreateList();
+                pss.RecreateScrollerList();
+            });
         }
 
         private static void TreeWindow(int id)

--- a/src/EC_BrowserFolders/Hooks/MakerSceneFolders.cs
+++ b/src/EC_BrowserFolders/Hooks/MakerSceneFolders.cs
@@ -24,8 +24,10 @@ namespace BrowserFolders.Hooks
         public MakerSceneFolders()
         {
             _folderTreeView =
-                new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+                new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path))
+                {
+                    CurrentFolderChanged = OnFolderChanged
+                };
 
             Harmony.CreateAndPatchAll(typeof(MakerSceneFolders));
         }
@@ -96,12 +98,11 @@ namespace BrowserFolders.Hooks
         {
             _currentRelativeFolder = _folderTreeView.CurrentRelativeFolder;
 
-            if (_hEditLoadSceneWindow == null) return;
-
-            var ccf = Traverse.Create(_hEditLoadSceneWindow);
-
-            ccf.Method("Create").GetValue();
-            ccf.Method("CreateListFilter").GetValue();
+            _hEditLoadSceneWindow.SafeProc(sw =>
+            {
+                sw.Create();
+                sw.CreateListFilter();
+            });
         }
 
         private static void TreeWindow(int id)

--- a/src/EC_BrowserFolders/packages.config
+++ b/src/EC_BrowserFolders/packages.config
@@ -1,12 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IllusionLibs.BepInEx" version="5.1.0" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.BepInEx.Harmony" version="2.0.3.1" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.EmotionCreators.Assembly-CSharp" version="2019.6.6" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass" version="2019.6.6" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.EmotionCreators.IL" version="2019.6.6" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" version="2017.4.24.1" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule" version="2017.4.24.1" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.EmotionCreators.UnityEngine.UI" version="2017.4.24.1" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionModdingAPI.ECAPI" version="1.13.0" targetFramework="net46" developmentDependency="true" />
+  <package id="BepInEx.Analyzers" version="1.0.4" targetFramework="net46" developmentDependency="true" />
+  <package id="ExtensibleSaveFormat.EmotionCreators" version="16.3.0" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx" version="5.4.13" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx.Harmony" version="2.5.2" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.EmotionCreators.Assembly-CSharp" version="2019.6.6.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.EmotionCreators.Assembly-CSharp-firstpass" version="2019.6.6.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.EmotionCreators.IL" version="2019.6.6.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.EmotionCreators.UniRx" version="2019.6.6.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.EmotionCreators.UnityEngine.CoreModule" version="2017.4.24.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.EmotionCreators.UnityEngine.IMGUIModule" version="2017.4.24.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.EmotionCreators.UnityEngine.UI" version="2017.4.24.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionModdingAPI.ECAPI" version="1.20.3" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/src/HS2_BrowserFolders/HS2_BrowserFolders.csproj
+++ b/src/HS2_BrowserFolders/HS2_BrowserFolders.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +23,7 @@
     <DefineConstants>TRACE;DEBUG;HS2</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>embedded</DebugType>
@@ -30,52 +33,65 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.3.1\lib\net35\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp.2020.5.29\lib\net46\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp.2020.5.29.4\lib\net46\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="BepInEx, Version=5.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.5.1.0\lib\net35\BepInEx.dll</HintPath>
+    <Reference Include="BepInEx, Version=5.4.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.5.4.13\lib\net35\BepInEx.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.3.1\lib\net35\BepInEx.Harmony.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\BepInEx.Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="HS2API, Version=1.12.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionModdingAPI.HS2API.1.12.2\lib\net46\HS2API.dll</HintPath>
+    <Reference Include="HS2API, Version=1.20.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionModdingAPI.HS2API.1.20.3\lib\net46\HS2API.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="HS2_ExtensibleSaveFormat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExtensibleSaveFormat.HoneySelect2.16.3.0\lib\net46\HS2_ExtensibleSaveFormat.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="IL, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.HoneySelect2.IL.2020.5.29\lib\net46\IL.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.HoneySelect2.IL.2020.5.29.4\lib\net46\IL.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Sirenix.Serialization, Version=2.0.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.HoneySelect2.Sirenix.Serialization.2020.5.29.4\lib\net46\Sirenix.Serialization.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="UniRx, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.HoneySelect2.UniRx.2020.5.29.4\lib\net46\UniRx.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11\lib\net46\UnityEngine.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.4\lib\net46\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11\lib\net46\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.4\lib\net46\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule.2018.4.11\lib\net46\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule.2018.4.11.4\lib\net46\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.HoneySelect2.UnityEngine.UI.2018.4.11\lib\net46\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.HoneySelect2.UnityEngine.UI.2018.4.11.4\lib\net46\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.HoneySelect2.UnityEngine.UIModule.2018.4.11\lib\net46\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.HoneySelect2.UnityEngine.UIModule.2018.4.11.4\lib\net46\UnityEngine.UIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -90,7 +106,34 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="..\Common_AIHS2\Common_AIHS2.projitems" Label="Shared" />
   <Import Project="..\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp.2020.5.29.4\build\IllusionLibs.HoneySelect2.Assembly-CSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp.2020.5.29.4\build\IllusionLibs.HoneySelect2.Assembly-CSharp.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.HoneySelect2.IL.2020.5.29.4\build\IllusionLibs.HoneySelect2.IL.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.HoneySelect2.IL.2020.5.29.4\build\IllusionLibs.HoneySelect2.IL.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.HoneySelect2.Sirenix.Serialization.2020.5.29.4\build\IllusionLibs.HoneySelect2.Sirenix.Serialization.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.HoneySelect2.Sirenix.Serialization.2020.5.29.4\build\IllusionLibs.HoneySelect2.Sirenix.Serialization.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.HoneySelect2.UniRx.2020.5.29.4\build\IllusionLibs.HoneySelect2.UniRx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.HoneySelect2.UniRx.2020.5.29.4\build\IllusionLibs.HoneySelect2.UniRx.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.HoneySelect2.UnityEngine.UI.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.HoneySelect2.UnityEngine.UI.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UI.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.HoneySelect2.UnityEngine.UIModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UIModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.HoneySelect2.UnityEngine.UIModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UIModule.targets'))" />
+  </Target>
+  <Import Project="..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp.2020.5.29.4\build\IllusionLibs.HoneySelect2.Assembly-CSharp.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.Assembly-CSharp.2020.5.29.4\build\IllusionLibs.HoneySelect2.Assembly-CSharp.targets')" />
+  <Import Project="..\packages\IllusionLibs.HoneySelect2.IL.2020.5.29.4\build\IllusionLibs.HoneySelect2.IL.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.IL.2020.5.29.4\build\IllusionLibs.HoneySelect2.IL.targets')" />
+  <Import Project="..\packages\IllusionLibs.HoneySelect2.Sirenix.Serialization.2020.5.29.4\build\IllusionLibs.HoneySelect2.Sirenix.Serialization.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.Sirenix.Serialization.2020.5.29.4\build\IllusionLibs.HoneySelect2.Sirenix.Serialization.targets')" />
+  <Import Project="..\packages\IllusionLibs.HoneySelect2.UniRx.2020.5.29.4\build\IllusionLibs.HoneySelect2.UniRx.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.UniRx.2020.5.29.4\build\IllusionLibs.HoneySelect2.UniRx.targets')" />
+  <Import Project="..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.targets')" />
+  <Import Project="..\packages\IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule.targets')" />
+  <Import Project="..\packages\IllusionLibs.HoneySelect2.UnityEngine.UI.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UI.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.UnityEngine.UI.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UI.targets')" />
+  <Import Project="..\packages\IllusionLibs.HoneySelect2.UnityEngine.UIModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UIModule.targets" Condition="Exists('..\packages\IllusionLibs.HoneySelect2.UnityEngine.UIModule.2018.4.11.4\build\IllusionLibs.HoneySelect2.UnityEngine.UIModule.targets')" />
 </Project>

--- a/src/HS2_BrowserFolders/packages.config
+++ b/src/HS2_BrowserFolders/packages.config
@@ -1,12 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IllusionLibs.BepInEx" version="5.1.0" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.BepInEx.Harmony" version="2.0.3.1" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.HoneySelect2.Assembly-CSharp" version="2020.5.29" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.HoneySelect2.IL" version="2020.5.29" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" version="2018.4.11" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule" version="2018.4.11" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.HoneySelect2.UnityEngine.UI" version="2018.4.11" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionLibs.HoneySelect2.UnityEngine.UIModule" version="2018.4.11" targetFramework="net46" developmentDependency="true" />
-  <package id="IllusionModdingAPI.HS2API" version="1.12.2" targetFramework="net46" developmentDependency="true" />
+  <package id="BepInEx.Analyzers" version="1.0.4" targetFramework="net46" developmentDependency="true" />
+  <package id="ExtensibleSaveFormat.HoneySelect2" version="16.3.0" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx" version="5.4.13" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx.Harmony" version="2.5.2" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.HoneySelect2.Assembly-CSharp" version="2020.5.29.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.HoneySelect2.IL" version="2020.5.29.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.HoneySelect2.Sirenix.Serialization" version="2020.5.29.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.HoneySelect2.UniRx" version="2020.5.29.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" version="2018.4.11.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.HoneySelect2.UnityEngine.IMGUIModule" version="2018.4.11.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.HoneySelect2.UnityEngine.UI" version="2018.4.11.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.HoneySelect2.UnityEngine.UIModule" version="2018.4.11.4" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionModdingAPI.HS2API" version="1.20.3" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/src/KK_FolderBrowser/KK_BrowserFolders.csproj
+++ b/src/KK_FolderBrowser/KK_BrowserFolders.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>TRACE;DEBUG;KK</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>embedded</DebugType>
@@ -32,20 +33,45 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BepInEx, Version=5.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.5.1.0\lib\net35\BepInEx.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="KKAPI, Version=1.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionModdingAPI.KKAPI.1.13.0\lib\net35\KKAPI.dll</HintPath>
+    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\lib\net35\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\lib\net35\Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BepInEx, Version=5.4.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.5.4.13\lib\net35\BepInEx.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\BepInEx.Harmony.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="ExtensibleSaveFormat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExtensibleSaveFormat.Koikatu.16.3.0\lib\net35\ExtensibleSaveFormat.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="KKAPI, Version=1.20.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionModdingAPI.KKAPI.1.20.3\lib\net35\KKAPI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2\lib\net35\UnityEngine.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\lib\net35\UnityEngine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\lib\net35\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -60,9 +86,29 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.dll" />
+    <Analyzer Include="..\packages\KoikatuCompatibilityAnalyzer.1.0.1\analyzers\dotnet\cs\KoikatuCompatibilityAnalyzer.dll" />
+  </ItemGroup>
   <Import Project="..\Common\Common.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) KK</PostBuildEvent>
   </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets'))" />
+  </Target>
+  <Import Project="..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp.targets')" />
+  <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <Import Project="..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets')" />
+  <Import Project="..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets')" />
+  <Import Project="..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets')" />
 </Project>

--- a/src/KK_FolderBrowser/packages.config
+++ b/src/KK_FolderBrowser/packages.config
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IllusionLibs.BepInEx" version="5.1.0" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionLibs.Koikatu.UnityEngine" version="5.6.2" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionModdingAPI.KKAPI" version="1.13.0" targetFramework="net35" developmentDependency="true" />
+  <package id="BepInEx.Analyzers" version="1.0.4" targetFramework="net35" developmentDependency="true" />
+  <package id="ExtensibleSaveFormat.Koikatu" version="16.3.0" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx" version="5.4.13" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx.Harmony" version="2.5.2" targetFramework="net35" />
+  <package id="IllusionLibs.Koikatu.Assembly-CSharp" version="2019.4.27.4" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.Koikatu.Assembly-CSharp-firstpass" version="2019.4.27.4" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.Koikatu.UnityEngine" version="5.6.2.4" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.Koikatu.UnityEngine.UI" version="5.6.2.4" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionModdingAPI.KKAPI" version="1.20.3" targetFramework="net35" developmentDependency="true" />
+  <package id="KoikatuCompatibilityAnalyzer" version="1.0.1" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/src/KK_Hooks_KK/KK_BrowserFolders_Hooks_KK.csproj
+++ b/src/KK_Hooks_KK/KK_BrowserFolders_Hooks_KK.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>embedded</DebugType>
@@ -30,36 +33,45 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.3.1\lib\net35\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27\lib\net35\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\lib\net35\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="BepInEx, Version=5.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.5.1.0\lib\net35\BepInEx.dll</HintPath>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\lib\net35\Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BepInEx, Version=5.4.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.5.4.13\lib\net35\BepInEx.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.3.1\lib\net35\BepInEx.Harmony.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\BepInEx.Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="KKAPI, Version=1.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionModdingAPI.KKAPI.1.13.0\lib\net35\KKAPI.dll</HintPath>
+    <Reference Include="ExtensibleSaveFormat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExtensibleSaveFormat.Koikatu.16.3.0\lib\net35\ExtensibleSaveFormat.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="KKAPI, Version=1.20.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionModdingAPI.KKAPI.1.20.3\lib\net35\KKAPI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2\lib\net35\UnityEngine.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\lib\net35\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2\lib\net35\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\lib\net35\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -85,8 +97,28 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.dll" />
+    <Analyzer Include="..\packages\KoikatuCompatibilityAnalyzer.1.0.1\analyzers\dotnet\cs\KoikatuCompatibilityAnalyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) KK</PostBuildEvent>
   </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets'))" />
+  </Target>
+  <Import Project="..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp.targets')" />
+  <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <Import Project="..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets')" />
+  <Import Project="..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets')" />
+  <Import Project="..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets')" />
 </Project>

--- a/src/KK_Hooks_KK/SceneFolders.cs
+++ b/src/KK_Hooks_KK/SceneFolders.cs
@@ -1,12 +1,11 @@
-﻿using System;
+﻿using HarmonyLib;
+using KKAPI.Utilities;
+using Studio;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Reflection.Emit;
-using BepInEx.Harmony;
-using HarmonyLib;
-using KKAPI.Utilities;
-using Studio;
 using UnityEngine;
 
 namespace BrowserFolders.Hooks.KK
@@ -19,24 +18,30 @@ namespace BrowserFolders.Hooks.KK
 
         public SceneFolders()
         {
-            _folderTreeView = new FolderTreeView(Utils.NormalizePath(UserData.Path), Path.Combine(Utils.NormalizePath(UserData.Path), @"studio\scene"));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+            _folderTreeView = new FolderTreeView(Utils.NormalizePath(UserData.Path), Path.Combine(Utils.NormalizePath(UserData.Path), @"studio\scene"))
+            {
+                CurrentFolderChanged = OnFolderChanged
+            };
 
             Harmony.CreateAndPatchAll(typeof(SceneFolders));
         }
+
+        private bool _guiActive;
 
         public void OnGui()
         {
             if (_studioInitObject != null)
             {
+                _guiActive = true;
                 var screenRect = new Rect((int)(Screen.width / 11.3f), (int)(Screen.height / 90f), (int)(Screen.width / 2.5f), (int)(Screen.height / 5f));
                 IMGUIUtils.DrawSolidBox(screenRect);
                 GUILayout.Window(362, screenRect, TreeWindow, "Select folder with scenes to view");
                 IMGUIUtils.EatInputInRect(screenRect);
             }
-            else
+            else if (_guiActive)
             {
                 _folderTreeView?.StopMonitoringFiles();
+                _guiActive = false;
             }
         }
 
@@ -99,12 +104,12 @@ namespace BrowserFolders.Hooks.KK
         {
             _currentRelativeFolder = _folderTreeView.CurrentRelativeFolder;
 
-            if (_studioInitObject == null) return;
-
-            var sls = typeof(SceneLoadScene);
-            sls.GetMethod("OnClickCancel", AccessTools.all)?.Invoke(_studioInitObject, null);
-            sls.GetMethod("InitInfo", AccessTools.all)?.Invoke(_studioInitObject, null);
-            sls.GetMethod("SetPage", AccessTools.all)?.Invoke(_studioInitObject, new object[] { SceneLoadScene.page });
+            _studioInitObject.SafeProc(sls =>
+            {
+                sls.OnClickCancel();
+                sls.InitInfo();
+                sls.SetPage(SceneLoadScene.page);
+            });
         }
 
         private static void TreeWindow(int id)

--- a/src/KK_Hooks_KK/StudioCharaFolders.cs
+++ b/src/KK_Hooks_KK/StudioCharaFolders.cs
@@ -1,10 +1,9 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using BepInEx.Harmony;
-using HarmonyLib;
+﻿using HarmonyLib;
 using KKAPI.Utilities;
 using Studio;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using UnityEngine;
 
 namespace BrowserFolders.Hooks.KK
@@ -29,6 +28,7 @@ namespace BrowserFolders.Hooks.KK
                 _lastEntry.FolderTreeView?.StopMonitoringFiles();
                 _lastEntry = null;
             }
+
             if (entry == null) return;
             _lastEntry = entry;
             var windowRect = new Rect((int) (Screen.width * 0.06f), (int) (Screen.height * 0.32f), (int) (Screen.width * 0.13f), (int) (Screen.height * 0.4f));
@@ -179,7 +179,8 @@ namespace BrowserFolders.Hooks.KK
 
             public void ApplyFilter()
             {
-                GetCharaFileInfos().RemoveAll(cfi => Utils.NormalizePath(Path.GetDirectoryName(cfi.file)) != CurrentFolder);
+                var currentFolder = CurrentFolder;
+                GetCharaFileInfos().RemoveAll(cfi => Utils.GetNormalizedDirectoryName(cfi.file) != currentFolder);
             }
 
             public void InitCharaList(bool force)
@@ -204,13 +205,13 @@ namespace BrowserFolders.Hooks.KK
 
             private List<CharaFileInfo> GetCharaFileInfos()
             {
-                return Traverse.Create(_charaList)?.Field<CharaFileSort>("charaFileSort")?.Value?.cfiList;
+                return _charaList.charaFileSort.cfiList;
             }
 
             private int GetSex()
             {
                 if (_sex == -1)
-                    _sex = Traverse.Create(_charaList).Field<int>("sex").Value;
+                    _sex = _charaList.sex;
                 return _sex;
             }
 

--- a/src/KK_Hooks_KK/StudioOutfitFolders.cs
+++ b/src/KK_Hooks_KK/StudioOutfitFolders.cs
@@ -34,21 +34,25 @@ namespace BrowserFolders.Hooks.KK
             }
         }
 
+        private bool _guiActive;
+
         public void OnGui()
         {
             if (_costumeInfoEntry != null)
             {
                 if (_costumeInfoEntry.isActive())
                 {
+                    _guiActive = true;
                     var windowRect = new Rect((int) (Screen.width * 0.06f), (int) (Screen.height * 0.32f),
                         (int) (Screen.width * 0.13f), (int) (Screen.height * 0.4f));
                     IMGUIUtils.DrawSolidBox(windowRect);
                     GUILayout.Window(363, windowRect, id => TreeWindow(), "Folder with outfits to view");
                     IMGUIUtils.EatInputInRect(windowRect);
                 }
-                else
+                else if (_guiActive)
                 {
                     _costumeInfoEntry.FolderTreeView?.StopMonitoringFiles();
+                    _guiActive = false;
                 }
             }
         }
@@ -75,7 +79,12 @@ namespace BrowserFolders.Hooks.KK
         {
             if (_costumeInfoEntry != null)
             {
-                _costumeInfoEntry.SaveFullList();
+                if (!_refilterOnly)
+                {
+                    // don't update results if we didn't get new ones
+                    _costumeInfoEntry.SaveFullList();
+                }
+
                 _costumeInfoEntry.ApplyFilter();
             }
         }
@@ -161,7 +170,8 @@ namespace BrowserFolders.Hooks.KK
 
             public void ApplyFilter()
             {
-                GetCharaFileInfos().RemoveAll(cfi => Utils.NormalizePath(Path.GetDirectoryName(cfi.file)) != CurrentFolder);
+                var currentFolder = CurrentFolder;
+                GetCharaFileInfos().RemoveAll(cfi => Utils.GetNormalizedDirectoryName(cfi.file) != currentFolder);
             }
 
             public void InitOutfitList()

--- a/src/KK_Hooks_KK/packages.config
+++ b/src/KK_Hooks_KK/packages.config
@@ -1,9 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IllusionLibs.BepInEx" version="5.1.0" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionLibs.BepInEx.Harmony" version="2.0.3.1" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionLibs.Koikatu.Assembly-CSharp" version="2019.4.27" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionLibs.Koikatu.UnityEngine" version="5.6.2" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionLibs.Koikatu.UnityEngine.UI" version="5.6.2" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionModdingAPI.KKAPI" version="1.13.0" targetFramework="net35" developmentDependency="true" />
+  <package id="BepInEx.Analyzers" version="1.0.4" targetFramework="net35" developmentDependency="true" />
+  <package id="ExtensibleSaveFormat.Koikatu" version="16.3.0" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx" version="5.4.13" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx.Harmony" version="2.5.2" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.Koikatu.Assembly-CSharp" version="2019.4.27.4" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.Koikatu.Assembly-CSharp-firstpass" version="2019.4.27.4" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.Koikatu.UnityEngine" version="5.6.2.4" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.Koikatu.UnityEngine.UI" version="5.6.2.4" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionModdingAPI.KKAPI" version="1.20.3" targetFramework="net35" developmentDependency="true" />
+  <package id="KoikatuCompatibilityAnalyzer" version="1.0.1" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/src/KK_Hooks_KKP/ClassroomFolders.cs
+++ b/src/KK_Hooks_KKP/ClassroomFolders.cs
@@ -1,16 +1,17 @@
-﻿using System.IO;
-using System.Linq;
-using ActionGame;
-using BepInEx.Harmony;
+﻿using ActionGame;
 using HarmonyLib;
 using Illusion.Extensions;
 using KKAPI.Utilities;
 using Manager;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
 using UnityEngine;
 
 namespace BrowserFolders.Hooks.KKP
 {
     [BrowserType(BrowserType.Classroom)]
+    [SuppressMessage("KK.Compatibility", "KKANAL03:Member is missing or has a different signature in KK Party.", Justification = "Library only used in KKP")]
     public class ClassroomFolders : IFolderBrowser
     {
         private static FolderTreeView _folderTreeView;
@@ -21,8 +22,10 @@ namespace BrowserFolders.Hooks.KKP
 
         public ClassroomFolders()
         {
-            _folderTreeView = new FolderTreeView(Overlord.GetUserDataRootPath(), Overlord.GetDefaultPath(0));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+            _folderTreeView = new FolderTreeView(Overlord.GetUserDataRootPath(), Overlord.GetDefaultPath(0))
+            {
+                CurrentFolderChanged = OnFolderChanged
+            };
 
             Overlord.Init();
 
@@ -96,7 +99,7 @@ namespace BrowserFolders.Hooks.KKP
 
         private static void OnFolderChanged()
         {
-            _customCharaFile?.CharFile?.Initialize();
+            _customCharaFile.SafeProc(ccf => ccf.CharFile.SafeProc(cf => cf.Initialize()));
         }
 
         private static void TreeWindow(int id)

--- a/src/KK_Hooks_KKP/FreeHFolders.cs
+++ b/src/KK_Hooks_KKP/FreeHFolders.cs
@@ -20,8 +20,10 @@ namespace BrowserFolders.Hooks.KKP
 
         public FreeHFolders()
         {
-            _folderTreeView = new FolderTreeView(Overlord.GetUserDataRootPath(), Overlord.GetDefaultPath(0));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+            _folderTreeView = new FolderTreeView(Overlord.GetUserDataRootPath(), Overlord.GetDefaultPath(0))
+            {
+                CurrentFolderChanged = OnFolderChanged
+            };
 
             Overlord.Init();
         }

--- a/src/KK_Hooks_KKP/HOutfitFolders.cs
+++ b/src/KK_Hooks_KKP/HOutfitFolders.cs
@@ -19,8 +19,10 @@ namespace BrowserFolders.Hooks.KKP
 
         public HOutfitFolders()
         {
-            _folderTreeView = new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+            _folderTreeView = new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path))
+            {
+                CurrentFolderChanged = OnFolderChanged
+            };
 
             Harmony.CreateAndPatchAll(typeof(HOutfitFolders));
         }
@@ -54,8 +56,7 @@ namespace BrowserFolders.Hooks.KKP
 
         private static void OnFolderChanged()
         {
-            if (_customCoordinateFile == null) return;
-            Traverse.Create(_customCoordinateFile).Method("Initialize").GetValue();
+            _customCoordinateFile.SafeProc(ccf => ccf.Initialize());
         }
 
         private static void TreeWindow(int id)

--- a/src/KK_Hooks_KKP/KK_BrowserFolders_Hooks_KKP.csproj
+++ b/src/KK_Hooks_KKP/KK_BrowserFolders_Hooks_KKP.csproj
@@ -12,6 +12,8 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>embedded</DebugType>
@@ -30,35 +33,44 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.3.1\lib\net35\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.5.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.KoikatsuParty.Assembly-CSharp.2019.4.27\lib\net35\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.KoikatsuParty.Assembly-CSharp.2019.4.27.4\lib\net35\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="BepInEx, Version=5.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.5.1.0\lib\net35\BepInEx.dll</HintPath>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\lib\net35\Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BepInEx, Version=5.4.13.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.BepInEx.5.4.13\lib\net35\BepInEx.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.0.3.1\lib\net35\BepInEx.Harmony.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\lib\net35\BepInEx.Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="KKAPI, Version=1.13.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionModdingAPI.KKAPI.1.13.0\lib\net35\KKAPI.dll</HintPath>
+    <Reference Include="ExtensibleSaveFormat, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ExtensibleSaveFormat.Koikatu.16.3.0\lib\net35\ExtensibleSaveFormat.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="KKAPI, Version=1.20.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionModdingAPI.KKAPI.1.20.3\lib\net35\KKAPI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2\lib\net35\UnityEngine.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\lib\net35\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2\lib\net35\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\lib\net35\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -82,8 +94,28 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\BepInEx.Analyzers.1.0.4\analyzers\dotnet\cs\BepInEx.Analyzers.dll" />
+    <Analyzer Include="..\packages\KoikatuCompatibilityAnalyzer.1.0.1\analyzers\dotnet\cs\KoikatuCompatibilityAnalyzer.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) KK</PostBuildEvent>
   </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\IllusionLibs.KoikatsuParty.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.KoikatsuParty.Assembly-CSharp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.KoikatsuParty.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.KoikatsuParty.Assembly-CSharp.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets'))" />
+  </Target>
+  <Import Project="..\packages\IllusionLibs.KoikatsuParty.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.KoikatsuParty.Assembly-CSharp.targets" Condition="Exists('..\packages\IllusionLibs.KoikatsuParty.Assembly-CSharp.2019.4.27.4\build\IllusionLibs.KoikatsuParty.Assembly-CSharp.targets')" />
+  <Import Project="..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.Harmony.2.5.2\build\IllusionLibs.BepInEx.Harmony.targets')" />
+  <Import Project="..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.2019.4.27.4\build\IllusionLibs.Koikatu.Assembly-CSharp-firstpass.targets')" />
+  <Import Project="..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.targets')" />
+  <Import Project="..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets" Condition="Exists('..\packages\IllusionLibs.Koikatu.UnityEngine.UI.5.6.2.4\build\IllusionLibs.Koikatu.UnityEngine.UI.targets')" />
 </Project>

--- a/src/KK_Hooks_KKP/MakerOutfitFolder.cs
+++ b/src/KK_Hooks_KKP/MakerOutfitFolder.cs
@@ -1,15 +1,16 @@
-﻿using System.IO;
-using BepInEx.Harmony;
-using ChaCustom;
+﻿using ChaCustom;
 using HarmonyLib;
 using KKAPI.Utilities;
 using Manager;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using UnityEngine;
 using UnityEngine.UI;
 
 namespace BrowserFolders.Hooks.KKP
 {
     [BrowserType(BrowserType.MakerOutfit)]
+    [SuppressMessage("KK.Compatibility", "KKANAL03:Member is missing or has a different signature in KK Party.", Justification = "Library only used in KKP")]
     public class MakerOutfitFolders : IFolderBrowser
     {
         private static Toggle _catToggle;
@@ -26,8 +27,10 @@ namespace BrowserFolders.Hooks.KKP
 
         public MakerOutfitFolders()
         {
-            _folderTreeView = new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+            _folderTreeView = new FolderTreeView(Utils.NormalizePath(UserData.Path), Utils.NormalizePath(UserData.Path))
+            {
+                CurrentFolderChanged = OnFolderChanged
+            };
 
             Harmony.CreateAndPatchAll(typeof(MakerOutfitFolders));
 
@@ -99,17 +102,22 @@ namespace BrowserFolders.Hooks.KKP
                     }
                 }
             }
-            if (!guiShown) _folderTreeView?.StopMonitoringFiles();
+
+            if (!guiShown)
+            {
+                _folderTreeView?.StopMonitoringFiles();
+            }
+
         }
 
         private static void OnFolderChanged()
         {
             if (_customCoordinateFile == null) return;
 
-            if (_loadOutfitToggle != null && _loadOutfitToggle.isOn || _saveOutfitToggle != null && _saveOutfitToggle.isOn)
+            var loadOutfitToggleIsOn = _loadOutfitToggle != null && _loadOutfitToggle.isOn;
+            if (loadOutfitToggleIsOn || _saveOutfitToggle != null && _saveOutfitToggle.isOn)
             {
-                // private bool Initialize(bool isDefaultDataAdd, bool reCreate)
-                Traverse.Create(_customCoordinateFile).Method("Initialize", _loadOutfitToggle?.isOn == true, false).GetValue();
+                _customCoordinateFile.Initialize(loadOutfitToggleIsOn, false);
             }
         }
 

--- a/src/KK_Hooks_KKP/NewGameFolders.cs
+++ b/src/KK_Hooks_KKP/NewGameFolders.cs
@@ -1,5 +1,4 @@
-﻿using HarmonyLib;
-using KKAPI.Utilities;
+﻿using KKAPI.Utilities;
 using Manager;
 using UnityEngine;
 
@@ -18,8 +17,10 @@ namespace BrowserFolders.Hooks.KKP
 
         public NewGameFolders()
         {
-            _folderTreeView = new FolderTreeView(Overlord.GetUserDataRootPath(), Overlord.GetDefaultPath(0));
-            _folderTreeView.CurrentFolderChanged = OnFolderChanged;
+            _folderTreeView = new FolderTreeView(Overlord.GetUserDataRootPath(), Overlord.GetDefaultPath(0))
+            {
+                CurrentFolderChanged = OnFolderChanged
+            };
 
             Overlord.Init();
         }
@@ -58,8 +59,7 @@ namespace BrowserFolders.Hooks.KKP
 
         private static void OnFolderChanged()
         {
-            if (_newGame != null)
-                Traverse.Create(_newGame).Method("CreateMaleList").GetValue();
+            _newGame.SafeProc(ng => ng.CreateMaleList());
         }
 
         private static void TreeWindow(int id)

--- a/src/KK_Hooks_KKP/Overlord.cs
+++ b/src/KK_Hooks_KKP/Overlord.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.IO;
-using ActionGame;
-using BepInEx.Harmony;
+﻿using ActionGame;
 using ChaCustom;
 using FreeH;
 using HarmonyLib;
+using System;
+using System.IO;
 using UnityEngine;
 using Object = UnityEngine.Object;
 

--- a/src/KK_Hooks_KKP/packages.config
+++ b/src/KK_Hooks_KKP/packages.config
@@ -1,9 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IllusionLibs.BepInEx" version="5.1.0" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionLibs.BepInEx.Harmony" version="2.0.3.1" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionLibs.KoikatsuParty.Assembly-CSharp" version="2019.4.27" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionLibs.Koikatu.UnityEngine" version="5.6.2" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionLibs.Koikatu.UnityEngine.UI" version="5.6.2" targetFramework="net35" developmentDependency="true" />
-  <package id="IllusionModdingAPI.KKAPI" version="1.13.0" targetFramework="net35" developmentDependency="true" />
+  <package id="BepInEx.Analyzers" version="1.0.4" targetFramework="net35" developmentDependency="true" />
+  <package id="ExtensibleSaveFormat.Koikatu" version="16.3.0" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx" version="5.4.13" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.BepInEx.Harmony" version="2.5.2" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.KoikatsuParty.Assembly-CSharp" version="2019.4.27.4" targetFramework="net35" />
+  <package id="IllusionLibs.Koikatu.Assembly-CSharp" version="2019.4.27" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.Koikatu.Assembly-CSharp-firstpass" version="2019.4.27.4" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.Koikatu.UnityEngine" version="5.6.2.4" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionLibs.Koikatu.UnityEngine.UI" version="5.6.2.4" targetFramework="net35" developmentDependency="true" />
+  <package id="IllusionModdingAPI.KKAPI" version="1.20.3" targetFramework="net35" developmentDependency="true" />
+  <package id="KoikatuCompatibilityAnalyzer" version="1.0.1" targetFramework="net35" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Was seeing 30-60s delays opening scene and coordinate lists in studio.

- Updated to public libs to avoid reflection costs
- Stopped "StopMonitoringFiles" running every OnGUI when idle
- enable/disable file watchers in separate thread (changing the value of `EnableRaisingEvents` can be very slow)
- fix filtering for studio outfits
- cache normalized directory names for filtering

Here's some numbers from the profiler:

#### Before
```
638,"BrowserFolders.Hooks.KK.StudioCharaFolders:OnGui ()",214300
638,"BrowserFolders.Hooks.KK.SceneFolders:OnGui ()",87300
988,"BrowserFolders.FolderTreeView:StartMonitoringFiles ()",529107800
```

#### After
```
632,"BrowserFolders.Hooks.KK.StudioCharaFolders:OnGui ()",10600
632,"BrowserFolders.Hooks.KK.SceneFolders:OnGui ()",1100
909,"BrowserFolders.FolderTreeView:StartMonitoringFiles ()",903000
```
