### PR TITLE
Only convert PNG files!

### DIFF
--- a/src/KKS_BrowserFolders_Hooks/Overlord.ImportHooks.cs
+++ b/src/KKS_BrowserFolders_Hooks/Overlord.ImportHooks.cs
@@ -95,11 +95,14 @@ namespace BrowserFolders.Hooks.KKS
             {
                 foreach (var file in Directory.GetFiles(dir))
                 {
-                    using (var reader = File.Open(file, FileMode.Open))
+                    if (file.EndsWith(".png"))
                     {
-                        var charFile = new ChaFile();
-                        if (charFile.LoadFileKoikatsu(new BinaryReader(reader), false, true))
-                            instance.convKoikatsuCha[sex].Add(new ConvertChaFileScene.PackData(file, 1)); //Mode must be 1
+                        using (var reader = File.Open(file, FileMode.Open))
+                        {
+                            var charFile = new ChaFile();
+                            if (charFile.LoadFileKoikatsu(new BinaryReader(reader), false, true))
+                                instance.convKoikatsuCha[sex].Add(new ConvertChaFileScene.PackData(file, 1)); //Mode must be 1
+                        }
                     }
                 }
             }

--- a/src/KKS_BrowserFolders_Hooks/Overlord.ImportHooks.cs
+++ b/src/KKS_BrowserFolders_Hooks/Overlord.ImportHooks.cs
@@ -95,7 +95,7 @@ namespace BrowserFolders.Hooks.KKS
             {
                 foreach (var file in Directory.GetFiles(dir))
                 {
-                    if (file.EndsWith(".png"))
+                    if (file.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
                     {
                         using (var reader = File.Open(file, FileMode.Open))
                         {


### PR DESCRIPTION
When other files besides `.png` files are present. The plugin will cause an exception, which will freeze KKS.
This PR checks, if the file ends with `.png` before converting it.

```
BoneModifier MessagePack.Formatters.KKABMX_Core_BoneModifierFormatter26.Deserialize(byte[], int, IFormatterResolver, int)
List<BoneModifier> MessagePack.Formatters.ListFormatter<KKABMX.Core.BoneModifier>.Deserialize(byte[], int, IFormatterResolver, int)
List<BoneModifier> MessagePack.LZ4MessagePackSerializer.DeserializeCore<List<BoneModifier>>(ArraySegment<byte>, IFormatterResolver)
List<BoneModifier> MessagePack.LZ4MessagePackSerializer.Deserialize<List<BoneModifier>>(byte[], IFormatterResolver)
List<BoneModifier> MessagePack.LZ4MessagePackSerializer.Deserialize<List<BoneModifier>>(byte[])
List<BoneModifier> KKABMX.Core.BoneController.ReadModifiers(PluginData)
[Debug  :Additional Card Info] ACI Data version 0 Found on import
FormatException: Too many bytes in what should have been a 7 bit encoded Int32.
  at System.IO.BinaryReader.Read7BitEncodedInt () [0x00013] in <fb001e01371b4adca20013e0ac763896>:0 
  at System.IO.BinaryReader.ReadString () [0x0000f] in <fb001e01371b4adca20013e0ac763896>:0 
  at (wrapper dynamic-method) ChaFile.DMD<ChaFile::LoadFileKoikatsu>(ChaFile,System.IO.BinaryReader,bool,bool)
  at BrowserFolders.Hooks.KKS.Overlord+ImportHooks.AddFilesToConvList (System.String dir, ConvertChaFileScene instance, System.Int32 sex) [0x00026] in <ad08665ad11c4091ad27778b5e5e277f>:0 
  at BrowserFolders.Hooks.KKS.Overlord+ImportHooks.GetDirs (System.String dir, ConvertChaFileScene instance, System.Int32 sex) [0x00061] in <ad08665ad11c4091ad27778b5e5e277f>:0 
  at BrowserFolders.Hooks.KKS.Overlord+ImportHooks.GetDirs (System.String dir, ConvertChaFileScene instance, System.Int32 sex) [0x00035] in <ad08665ad11c4091ad27778b5e5e277f>:0 
  at BrowserFolders.Hooks.KKS.Overlord+ImportHooks.GetDirs (System.String dir, ConvertChaFileScene instance, System.Int32 sex) [0x00035] in <ad08665ad11c4091ad27778b5e5e277f>:0 
  at BrowserFolders.Hooks.KKS.Overlord+ImportHooks.GetDirs (System.String dir, ConvertChaFileScene instance, System.Int32 sex) [0x00035] in <ad08665ad11c4091ad27778b5e5e277f>:0 
  at BrowserFolders.Hooks.KKS.Overlord+ImportHooks.GetDirs (System.String dir, ConvertChaFileScene instance, System.Int32 sex) [0x00035] in <ad08665ad11c4091ad27778b5e5e277f>:0 
  at BrowserFolders.Hooks.KKS.Overlord+ImportHooks.GetDirs (System.String dir, ConvertChaFileScene instance, System.Int32 sex) [0x00035] in <ad08665ad11c4091ad27778b5e5e277f>:0 
  at BrowserFolders.Hooks.KKS.Overlord+ImportHooks.ConvertStartHookPre (ConvertChaFileScene __instance) [0x00026] in <ad08665ad11c4091ad27778b5e5e277f>:0 
  at (wrapper dynamic-method) ConvertChaFileScene.DMD<ConvertChaFileScene::Start>(ConvertChaFileScene)
 
(Filename: <fb001e01371b4adca20013e0ac763896> Line: 0)
```