### PR TITLE
[KK][KKS] Save page/scroll bar when selecting scenes

### DIFF
--- a/src/Common/BrowserFoldersUtil.cs
+++ b/src/Common/BrowserFoldersUtil.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+#if KK || KKS
+using Studio;
+#endif
+
+
+namespace BrowserFolders
+{
+    public static class BrowserFoldersUtil
+    {
+#if KK || KKS
+        public static void ScrollToSelected(SceneLoadScene sls)
+        {
+            if (sls == null)
+                return;
+            
+            //Save page value to a local variable as it may be initialized by KK
+            int page = Mathf.Clamp(SceneLoadScene.page, 0, sls.pageNum - 1);
+
+            sls.DelayedInvoke(() => {
+                var scroll = sls.GetComponentInChildren<UnityEngine.UI.Scrollbar>();
+                if (scroll != null)
+                    scroll.value = 1.0f - (float)page / (sls.pageNum - 1);
+
+#if KK
+                //Someone will reset it.
+                sls.SetPage(page);
+#endif
+            }, 2);
+        }
+#endif
+
+    }
+}
+

--- a/src/Common/Common.projitems
+++ b/src/Common/Common.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)BrowserFoldersUtil.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectoryTree.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FolderTreeView.cs" />

--- a/src/Common/Utils.cs
+++ b/src/Common/Utils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -96,6 +97,18 @@ namespace BrowserFolders
         public static bool IsEmpty(this UnityEngine.Rect value)
         {
             return value.height == 0 || value.width == 0;
+        }
+
+        public static void DelayedInvoke(this UnityEngine.MonoBehaviour monoBehaviour, System.Action action, int delayedFrames)
+        {
+            monoBehaviour.StartCoroutine(DelayedInvoke(action, delayedFrames));
+        }
+
+        private static IEnumerator DelayedInvoke(System.Action action, int delayedFrames)
+        {
+            while (delayedFrames-- > 0)
+                yield return null;
+            action.Invoke();
         }
     }
 }

--- a/src/KKS_BrowserFolders_Hooks/SceneFolders.cs
+++ b/src/KKS_BrowserFolders_Hooks/SceneFolders.cs
@@ -72,6 +72,7 @@ namespace BrowserFolders.Hooks.KKS
             if (_folderTreeView.CurrentFolder == null)
                 _folderTreeView.CurrentFolder = _folderTreeView.DefaultPath;
             _folderTreeView.ScrollListToSelected();
+            BrowserFoldersUtil.ScrollToSelected(__instance);
         }
 
         [HarmonyPrefix]

--- a/src/KK_Hooks_KK/SceneFolders.cs
+++ b/src/KK_Hooks_KK/SceneFolders.cs
@@ -72,6 +72,7 @@ namespace BrowserFolders.Hooks.KK
             if (_folderTreeView.CurrentFolder == null)
                 _folderTreeView.CurrentFolder = _folderTreeView.DefaultPath;
             _folderTreeView.ScrollListToSelected();
+            BrowserFoldersUtil.ScrollToSelected(__instance);
         }
 
         [HarmonyPrefix]


### PR DESCRIPTION
I have made the following changes to KK/KKS.
Please merge if you like.

- KKS
When scene select is opened, the previously opened page is loaded. However, the scrollbar was reset.
Since it is a bit troublesome when more scenes are added, we fixed it so that the scrollbar is set to the position where it was opened.

- KK.
Both the scene select page and the scrollbar are reset each time it is opened. Scrollbars are also reset.
Fixed to open the previously opened page.

![image](https://github.com/ManlyMarco/Illusion_BrowserFolders/assets/4230203/d1720ae8-d7dc-4402-ba0b-e0c1e2f55cea)

