### PR TITLE
[HS2] Fixed a bug that caused failure to save cards in subdirectories

### DIFF
--- a/src/HS2_BrowserFolders/NestedFilenamesMainGamePatch.cs
+++ b/src/HS2_BrowserFolders/NestedFilenamesMainGamePatch.cs
@@ -3,6 +3,7 @@ using System.IO;
 using AIChara;
 using HarmonyLib;
 using KKAPI;
+using KKAPI.Chara;
 
 namespace BrowserFolders
 {
@@ -48,6 +49,13 @@ namespace BrowserFolders
             var gmode = KoikatuAPI.GetCurrentGameMode();
             if (gmode != GameMode.MainGame && gmode != GameMode.Maker) return true;
             if (path == null) return true;
+
+            if (path == __instance.charaFileName)
+            {
+                __result = __instance.GetSourceFilePath();
+                if (!string.IsNullOrEmpty(__result))
+                    return false;
+            }
 
             if (!path.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
                 path += ".png";


### PR DESCRIPTION
#49 
When the save process was running in the main game to a card in a subdirectory, a copy was saved directly under the female directory.